### PR TITLE
Add Nick Launches

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,3 +154,4 @@ Sponsored by [The Next AI Directory](https://thenextaidirectory.com)
 | [FutureAI.tools](https://thenextaidirectory.com/go/futureai-tools) | 0 | Best AI tools directory |
 | [Tools Hub AI](https://thenextaidirectory.com/go/tools-hub-ai) | 0 | Top AI tools for images, video and code |
 | [Twivv](https://thenextaidirectory.com/go/twivv) | 0 | AI news, reviews and tool directory |
+| [Nick Launches](https://nicklaunches.com/) |  |  |


### PR DESCRIPTION
Adds Nick Launches to the directory list.

Nick Launches is a launch platform for builders, AI startups, and SaaS founders to get discovered and earn a permanent dofollow backlink.

Edited `readme.md` using the repository's existing format (markdown table).